### PR TITLE
builds separated from unit test executions and introduced matcher tha…

### DIFF
--- a/.github/workflows/build [linux].yml
+++ b/.github/workflows/build [linux].yml
@@ -1,4 +1,4 @@
-name: valgrind
+name: linux-build
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
 
 jobs:
   build:
@@ -28,14 +28,3 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-    - name: Installing valgrind
-      run: sudo apt install valgrind
-
-    - name: Running valgrind
-      working-directory: ${{github.workspace}}/build/tests
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: 
-        cd ${{github.workspace}}/build/tests/Array && valgrind -s -v --error-exitcode=1 --leak-check=full ./ArrayTestSuite &&
-        cd ${{github.workspace}}/build/tests/Stack && valgrind -s -v --error-exitcode=1 --leak-check=full ./StackTestSuite

--- a/.github/workflows/build [macos].yml
+++ b/.github/workflows/build [macos].yml
@@ -1,4 +1,4 @@
-name: valgrind
+name: build [macos]
 
 on:
   push:
@@ -8,14 +8,14 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
 
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ macos-latest ]
 
     steps:
     - uses: actions/checkout@v3
@@ -28,14 +28,3 @@ jobs:
     - name: Build
       # Build your program with the given configuration
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-    - name: Installing valgrind
-      run: sudo apt install valgrind
-
-    - name: Running valgrind
-      working-directory: ${{github.workspace}}/build/tests
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: 
-        cd ${{github.workspace}}/build/tests/Array && valgrind -s -v --error-exitcode=1 --leak-check=full ./ArrayTestSuite &&
-        cd ${{github.workspace}}/build/tests/Stack && valgrind -s -v --error-exitcode=1 --leak-check=full ./StackTestSuite

--- a/.github/workflows/build [windows].yml
+++ b/.github/workflows/build [windows].yml
@@ -1,4 +1,4 @@
-name: valgrind
+name: build [windows]
 
 on:
   push:
@@ -8,14 +8,14 @@ on:
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
-  BUILD_TYPE: Debug
+  BUILD_TYPE: Release
 
 jobs:
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: [ ubuntu-latest ]
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -23,19 +23,8 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}\build -S ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-
-    - name: Installing valgrind
-      run: sudo apt install valgrind
-
-    - name: Running valgrind
-      working-directory: ${{github.workspace}}/build/tests
-      # Execute tests defined by the CMake configuration.
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: 
-        cd ${{github.workspace}}/build/tests/Array && valgrind -s -v --error-exitcode=1 --leak-check=full ./ArrayTestSuite &&
-        cd ${{github.workspace}}/build/tests/Stack && valgrind -s -v --error-exitcode=1 --leak-check=full ./StackTestSuite
+      run: cmake --build ${{github.workspace}}\build

--- a/.github/workflows/unit-tests [linux].yml
+++ b/.github/workflows/unit-tests [linux].yml
@@ -1,10 +1,10 @@
-name: windows
+name: unit tests [linux]
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ '**' ] # '**' it used to match all existing branches
   pull_request:
-    branches: [ "main" ]
+    branches: [ '**' ] # '**' it used to match all existing branches
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -15,7 +15,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: windows-latest
+    runs-on: [ ubuntu-latest ]
 
     steps:
     - uses: actions/checkout@v3
@@ -23,14 +23,14 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}\build -S ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}\build
+      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Test
-      working-directory: ${{github.workspace}}\build\tests
+      working-directory: ${{github.workspace}}/build/tests
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: cd ${{github.workspace}}\build\tests\Array\Debug && start ArrayTestSuite.exe && cd ${{github.workspace}}\build\tests\Stack\Debug && start StackTestSuite.exe
+      run: ./run_all_unit_tests.sh

--- a/.github/workflows/unit-tests [macos].yml
+++ b/.github/workflows/unit-tests [macos].yml
@@ -1,10 +1,10 @@
-name: linux
+name: unit tests [macos]
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ '**' ] # '**' it used to match all existing branches
   pull_request:
-    branches: [ "main" ]
+    branches: [ '**' ] # '**' it used to match all existing branches
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -15,7 +15,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ macos-latest ]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/unit-tests [windows].yml
+++ b/.github/workflows/unit-tests [windows].yml
@@ -1,10 +1,10 @@
-name: macos
+name: unit tests [windows]
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ '**' ] # '**' it used to match all existing branches
   pull_request:
-    branches: [ "main" ]
+    branches: [ '**' ] # '**' it used to match all existing branches
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -15,7 +15,7 @@ jobs:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.
     # You can convert this to a matrix build if you need cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: [ macos-latest ]
+    runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v3
@@ -23,14 +23,14 @@ jobs:
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}\build -S ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
     - name: Build
       # Build your program with the given configuration
-      run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
+      run: cmake --build ${{github.workspace}}\build
 
     - name: Test
-      working-directory: ${{github.workspace}}/build/tests
+      working-directory: ${{github.workspace}}\build\tests
       # Execute tests defined by the CMake configuration.
       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ./run_all_unit_tests.sh
+      run: cd ${{github.workspace}}\build\tests\Array\Debug && start ArrayTestSuite.exe && cd ${{github.workspace}}\build\tests\Stack\Debug && start StackTestSuite.exe


### PR DESCRIPTION
…t allows to execute jobs on every branch (there is no need to specify it by name anymore) (#5)