### PR TITLE
issue with running weekly every minute past 7 every Monday fixed

### DIFF
--- a/.github/workflows/weekly-run.yml
+++ b/.github/workflows/weekly-run.yml
@@ -3,7 +3,7 @@ name: weekly-run
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    - cron:  '* 7 * * MON'
+    - cron:  '0 5 * * SUN'
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)


### PR DESCRIPTION
Issue: weekly CI job was running too many times because there was no specification for minutes that it should run (so it was triggered every minute past 7 every Monday)
Fix: Now weekly CI job should be triggered only on 5:00am every Sunday 