### PR TITLE
update checkout action to the newest available version

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.0
 
     - name: Configure git
       run: git config --global user.email "${{ secrets.EMAIL }}" && git config --global user.name "${{ secrets.AGENT_NAME }}"

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.0
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [ ubuntu-22.04 ]
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.0
 
     - name: Configure Docker
       working-directory: ${{github.workspace}}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -29,32 +29,32 @@ jobs:
 
   ubsan:
     runs-on: [ ubuntu-latest ]
-    
+
     steps:
     - uses: actions/checkout@v3.5.2
-    
+
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DUBSan=ON
-    
+
     - name: Build repository
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-    
+
     - name: Running USan
       working-directory: ${{github.workspace}}/build/tests
       run: ./run_all_unit_tests.sh
 
   lsan:
     runs-on: [ ubuntu-latest ]
-    
+
     steps:
-      - uses: actions/checkout@v3.5.2
-    
+      - uses: actions/checkout@v4.1.0
+
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}/build -S ${{github.workspace}} -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DLSan=ON
-    
+
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
-    
+
       - name: Running LSan
         working-directory: ${{github.workspace}}/build/tests
         run: ./run_all_unit_tests.sh

--- a/.github/workflows/unit-tests-linux.yml
+++ b/.github/workflows/unit-tests-linux.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.0
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/unit-tests-macos.yml
+++ b/.github/workflows/unit-tests-macos.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [ macos-latest ]
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.0
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/unit-tests-windows.yml
+++ b/.github/workflows/unit-tests-windows.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.0
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ '**' ] # '**' it used to match all existing branches
   workflow_dispatch:   # workflow dispatch is enabling 'Re-run all jobs' button in github UI
- 
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
@@ -19,7 +19,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.0
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
@@ -31,7 +31,7 @@ jobs:
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}
 
     - name: Installing valgrind
-      run: sudo apt install valgrind
+      run: sudo apt update --fix-missing && sudo apt install valgrind
 
     - name: Running valgrind
       working-directory: ${{github.workspace}}/build/tests

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
 
     steps:
-    - uses: actions/checkout@v3.5.2
+    - uses: actions/checkout@v4.1.0
 
     - name: Configure CMake
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.


### PR DESCRIPTION
1. Update checkout GitHub action to 4.1 version
2. Fixed issue with installing valgrind